### PR TITLE
Fix Signin and Signup links

### DIFF
--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -9,10 +9,11 @@ $twitter-blue: #4099ff;
 $google-red: #d34836;
 
 form {
-  border-right: 2px solid $l-grey;
-
-  .signin {
+  &.signin {
     padding-top: 40px;
+  }
+  &.pipe {
+    border-right: 2px solid $l-grey;
   }
 }
 

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -48,7 +48,7 @@
 							<%= render "cart_dropdown" %>
 						</span>						
 						<span class="white-text small-text">&nbsp;|&nbsp;</span>
-						<a href="#" class="black-text">SIGN IN</a>
+						<%= link_to "SIGN IN", user_signin_path, class: "black-text" %>
 					</div>
 				</div>
 		

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
 <div class="row container">
 <h2>Create Account</h2>
   <div class = "container col l8 signup">
-    <form >
+    <form class="pipe">
       <div class="row entry">
         <div class="input-field">
           <!-- <i class="material-icons prefix">account_circle</i> -->
@@ -37,7 +37,9 @@
       </button>
       </div>
     </form>
-    <p class="comments">Got an account? <a href="#">Sign In</a></p>
+    <p class="comments">Got an account? 
+      <%= link_to "Sign In", user_signin_path %>
+    </p>
   </div>
   <div class="container col l4">
     <div class="row signup">

--- a/app/views/users/signin.html.erb
+++ b/app/views/users/signin.html.erb
@@ -2,7 +2,7 @@
 <div class="signin row container">
   <div class="describe"><h2>Sign In</h2></div>
   <div class = "container col l8 signin">
-    <form class="signin">
+    <form class="signin pipe">
       <div class="row entry">
         <div class="input-field">
           <!-- <i class="material-icons prefix">email</i> -->
@@ -23,7 +23,9 @@
       </button>
       </div>
     </form>
-    <p class="comments">If you do not have an account, please? <a href="#">Sign Up</a></p>
+    <p class="comments">If you do not have an account, please
+    <%= link_to "Sign Up", user_new_path %>
+    </p>
   </div>
   <div class="container col l4">
     <div class="row signin">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # Example resource route
   # (maps HTTP verbs to controller actions automatically):
-  resources :users
+  # resources :users
 
   resources :products
 
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get "/checkout", to: "checkout#index"
   get "/cart", to: "cart#index"
   get "/contact", to: "landing#contact"
+  get "/users/new", to: "users#new", as: "user_new"
+  get "/users/signin", to: "users#signin", as: "user_signin"
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 


### PR DESCRIPTION
Why?
When the signin link on the landing page is clicked or the signup in the
signin page, the signin/signup page should be loaded.

How?
Create route to the signin page
Use link_to to add the link to the signin page
Create route to the signup page,
Add signup link to the signin page
Add signin link to the signup page.
