### PR TITLE
Fix heroku bug on trying to seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+Subcategory.destroy_all
 Category.destroy_all
 Product.destroy_all
 ProductImageLink.destroy_all


### PR DESCRIPTION
Why?
The seed file throws an error because in the process of deleting the records in the Category model, it has to delete all records in the Subcategory model which still reference records in the Category model.

How?
Added code to delete all Subcategories before attempting to delete Categories
