### PR TITLE
Fix SendGrid Mail Sending on Production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,9 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :smtp
+
 end
+
+# configure application default URL host
+Rails.application.routes.default_url_options[:host] =
+  "https://getmyshop-staging.herokuapp.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,6 @@ Rails.application.routes.draw do
       get "forgot-password", as: :forgot
       get "activate/:email/:code", to: "users#activate", as: "activate"
     end
-    get "users/forgot-password", to: "users#forgot_password", as: "forgot"
   end
   # get "/users/new", to: "users#new", as: "user_new"
   # get "/users/signin", to: "users#signin", as: "user_signin"


### PR DESCRIPTION
Why?
When a customer creates an account
A welcome message should be sent to the user's mail

How?
set the host default url option to the heroku app staging url

https://www.pivotaltracker.com/story/show/111533858
[#111533858]
