### PR TITLE
Fix Show Password Checkbox Display Angle

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -85,7 +85,7 @@ $(document).ready(function() {
   $("#user_email").on("focusout keyup change", emailChecker);
   $("#user_password").on("focusout keyup change", passwordChecker);
 
-  $("#show_password").change(function() {
+  $("#show-password").change(function() {
     if ($(this).is(":checked")) {
       $(".pword").attr("type","text");
     } else {

--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -212,6 +212,15 @@ form {
   margin-top: 3em;
 }
 
+.forgot-password {
+  #show-password:checked + [for="show-password"]::before {
+    -moz-transform: rotate(45deg);
+    -ms-transform: rotate(45deg);
+    -o-transform: rotate(45deg);
+    -webkit-transform: rotate(45deg);
+  }
+}
+
 .pword-message {
   color: $my-green;
   font-size: 0.9em;

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -42,9 +42,9 @@
               <%= f.password_field :password, required: "required", class: "pword" %>
             </div>
 
-            <div class="">
-              <input type="checkbox" id="show_password" />
-              <label for="show_password" title="show password">show password</label>
+            <div class="forgot-password">
+              <input type="checkbox" id="show-password" />
+              <label for="show-password" title="show password">show password</label>
             </div>
 
             <div class="submit-div center">

--- a/app/views/users/reset_password.html.erb
+++ b/app/views/users/reset_password.html.erb
@@ -10,9 +10,9 @@
             <span class="field-error" id="password-error"></span>
             <%= password_field_tag :password, "", class: "pword", id: "reset_password"%>
           </div>
-          <div class="">
-            <input type="checkbox" id="show_password" />
-            <label for="show_password" title="show password">show password</label>
+          <div class="forgot-password">
+            <input type="checkbox" id="show-password" />
+            <label for="show-password" title="show password">show password</label>
           </div>
         </div>
         <div class="row submit-forgot">


### PR DESCRIPTION
Why?
When I click on the show password checkbox, the checkmark should be displayed at the appropriate angle irrespective of my browser type.

How?
Targetting the element and adding rotate property to all browser options

https://www.pivotaltracker.com/story/show/112509151
[finishes #112509151]
