### PR TITLE
fix display related products feature

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,9 +4,7 @@ class ProductsController < ApplicationController
 
   def show
     @product = Product.find_by_id(params[:id])
-    category = @product.category.id
-    @related_products = Category.find(category).
-                        products.order("RANDOM()").limit(3)
-    redirect_to root_path if @product.nil?
+    category = @product.category
+    @related_products = category.related_products(@product.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,8 @@ class Category < ActiveRecord::Base
   has_many :subcategories
   has_many :products, through: :subcategories
   validates :name, presence: true
+
+  def related_products(product_id)
+    products.where.not(id: product_id).order("RANDOM()").limit(3)
+  end
 end


### PR DESCRIPTION
Why?
Remove current product on product description page from related products view.

How?
Wrote query statement in category model to exclude current product

https://www.pivotaltracker.com/story/show/112904837

[finished #112904837]
