### PR TITLE
117351601 disable add to cart button 

### DIFF
--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -133,8 +133,15 @@
   }
 }
 
-.products-input {
+.p-input {
   height: 2.3rem !important;
+}
+
+.my-disabled {
+  background: $disabled-grey;
+  box-shadow: none;
+  color: $disabled-text;
+  pointer-events: none;
 }
 
 hr {

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -133,7 +133,7 @@
   }
 }
 
-.p-input {
+.products-input {
   height: 2.3rem !important;
 }
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -43,3 +43,5 @@ $twitter-blue: #00aced;
 $deep-twitter-blue: #00a8e6;
 $light-grey: #fafafa;
 $light-red: #f44336;
+$disabled-grey: #dfdfdf;
+$disabled-text: #9f9f9f;

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -43,4 +43,12 @@ module ProductsHelper
       %w(Small small)
     ]
   end
+
+  def add_to_cart
+    if @product.quantity > 0
+      submit_tag "ADD TO CART", class: "waves-effect btn p-input"
+    else
+      submit_tag "ADD TO CART", class: "btn p-input my-disabled"
+    end
+  end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -46,9 +46,11 @@ module ProductsHelper
 
   def add_to_cart
     if @product.quantity > 0
-      submit_tag "ADD TO CART", class: "waves-effect btn p-input"
+      submit_tag "ADD TO CART", class: "waves-effect btn products-input"
     else
-      submit_tag "ADD TO CART", class: "btn p-input my-disabled"
+      submit_tag "ADD TO CART",
+                 class: "btn products-input disabled",
+                 disabled: true
     end
   end
 end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -79,7 +79,9 @@
           <div class="col s2">
             <%= number_field_tag :quantity, 1, in: 1..@product.quantity, step: 1 %>
           </div>
-          <div class="col s4"><%= submit_tag "ADD TO CART", class: "waves-effect btn products-input", id: "submit"%></div>
+          <div class="col s4">
+            <%= add_to_cart %>
+          </div>
          <%= wishlist_add_link %>
         </div>
       </div>

--- a/spec/features/product_description_page_spec.rb
+++ b/spec/features/product_description_page_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe "Product Show page", type: :feature do
       end
 
       context "product still in stock" do
-        it { is_expected.to have_css(".p-input") }
+        it { is_expected.to have_css(".products-input") }
       end
 
       context "product out of stock" do
         it do
           out_of_stock_product = create(:product, quantity: 0)
           visit product_path(out_of_stock_product)
-          is_expected.to have_css(".my-disabled")
+          is_expected.to have_button("ADD TO CART", disabled: true)
         end
       end
     end

--- a/spec/features/product_description_page_spec.rb
+++ b/spec/features/product_description_page_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe "Product Show page", type: :feature do
           "img[src='#{product.product_image_links.first.link_name}']"
         )
       end
+
+      context "product still in stock" do
+        it { is_expected.to have_css(".p-input") }
+      end
+
+      context "product out of stock" do
+        it do
+          out_of_stock_product = create(:product, quantity: 0)
+          visit product_path(out_of_stock_product)
+          is_expected.to have_css(".my-disabled")
+        end
+      end
     end
 
     describe "related products in the '.related-products' div" do


### PR DESCRIPTION
#### What does this PR do?

Disables add to cart button for products that are out of stock
#### Description of Task to be completed?

Add disable class to `add to cart` button
#### How should this be manually tested?

Visit a product page and click on `add to cart` for a product that is out of stock. 
#### Any background context you want to provide?

When a product is no longer in stock, a customer should not be able to add it to cart.
#### What are the relevant pivotal tracker stories?
#117351601
